### PR TITLE
Specify mirror directories as urls for crusher

### DIFF
--- a/cray-sles15-zen3/crusher/spack.yaml
+++ b/cray-sles15-zen3/crusher/spack.yaml
@@ -14,8 +14,8 @@ spack:
       modules:
         lmod: /sw/crusher/spack-envs/base/modules
   mirrors:
-    facility_builds: /sw/crusher/spack-env/mirrors/builds
-    source_mirror: /sw/sources/facility-spack/source_mirror
+    facility_builds: file:///sw/crusher/spack-env/mirrors/builds
+    source_mirror: file:///sw/sources/facility-spack/source_mirror
   repos: [] # Add any custom packages here
   config:
     install_tree:


### PR DESCRIPTION
Recent changes to spack seem to get confused about identifying full mirror paths as local files. See, for example, this spack issue:

https://github.com/spack/spack/issues/34532

When trying to install spack packages on crusher I was getting errors like this

```
==> Error: unknown url type: 'sw/crusher/spack-env/mirrors/builds/build_cache/index.json'
```

An easy solution is to explicitly specify the path as a file with the `file://` prefix. These changes are for the configuration on crusher. Other configurations might also need to be changed.